### PR TITLE
Add shell tests

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,2 @@
+brew "bats"
+brew "shellcheck"

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ COPY . /
 
 RUN npm ci
 
-ENTRYPOINT ["node", "/index.js"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+
+sh -c "node index.js $*"

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,14 @@
+#!/bin/sh
+# script/bootstrap: Resolve dependencies that the application requires to run.
+
+# Exit if any subcommand fails
+set -e
+
+# Ensure we're always running from the project root
+cd "$(dirname "$0")/.."
+
+if [ -f "Brewfile" ] && [ "$(uname -s)" = "Darwin" ]; then
+  brew bundle check >/dev/null 2>&1  || {
+    echo "==> Installing Homebrew dependencies…"
+    brew bundle
+  }

--- a/script/test
+++ b/script/test
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Exit if any subcommand fails
+set -e
+
+# Ensure we're always running from the project root
+cd "$(dirname "$0")/.."
+
+bats test/*.bats
+shellcheck *.sh

--- a/test/entrypoint.bats
+++ b/test/entrypoint.bats
@@ -1,0 +1,15 @@
+#!/usr/bin/env bats
+
+function setup() {
+  # Ensure a valid payload that this script can use
+  export GITHUB_EVENT_PATH="${GITHUB_EVENT_PATH-"${BATS_TEST_DIRNAME}/event.json"}"
+  # Ensure GITHUB_WORKSPACE is set
+  export GITHUB_WORKSPACE="${GITHUB_WORKSPACE-"${BATS_TEST_DIRNAME}/.."}"
+  
+}
+
+@test "entrypoint runs successfully" {
+  run $GITHUB_WORKSPACE/entrypoint.sh
+  echo "$output"
+  [ "$status" -eq 0 ]
+}

--- a/test/event.json
+++ b/test/event.json
@@ -1,0 +1,7 @@
+{
+  "repository": {
+    "owner": {
+      "login": "test-owner-login"
+    }
+  }
+}


### PR DESCRIPTION
Love this @JasonEtco! Thought I'd help you out with some tests based on the pattern I've seen in https://github.com/actions. Basically just changes the `dockerfile` to use a shell script that can be tested instead of calling `node index.js` directly, then sets up [Bats](https://github.com/sstephenson/bats) to test that script can execute against a valid payload.